### PR TITLE
Update to Spring 4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 	<properties>
 		<spring-data-releasetrain.version>Fowler-BUILD-SNAPSHOT</spring-data-releasetrain.version>
 		<java.version>1.8</java.version>
+		<spring.version>4.2.0.BUILD-SNAPSHOT</spring.version>
 	</properties>
 
 	<dependencies>
@@ -59,12 +60,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 			<groupId>org.javamoney</groupId>
 			<artifactId>moneta</artifactId>
 			<version>1.0-RC1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-tx-events</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/springsource/restbucks/Restbucks.java
+++ b/src/main/java/org/springsource/restbucks/Restbucks.java
@@ -25,14 +25,12 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.hal.CurieProvider;
 import org.springframework.hateoas.hal.DefaultCurieProvider;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.event.TransactionAwareApplicationEventMulticaster;
 
 /**
  * Central application class containing both general application and web configuration as well as a main-method to
@@ -66,16 +64,12 @@ public class Restbucks extends SpringBootServletInitializer {
 	}
 
 	@Configuration
-	@EnableAsync
+	@EnableAsync(proxyTargetClass = true)
 	@Import(JacksonCustomizations.class)
 	@EntityScan(basePackageClasses = { Restbucks.class, Jsr310JpaConverters.class })
 	@EnableAutoConfiguration
 	@ComponentScan(includeFilters = @Filter(Service.class), useDefaultFilters = false)
 	static class ApplicationConfiguration {
-
-		public @Bean ApplicationEventMulticaster applicationEventMulticaster() {
-			return new TransactionAwareApplicationEventMulticaster();
-		}
 	}
 
 	/**

--- a/src/main/java/org/springsource/restbucks/payment/OrderPaidEvent.java
+++ b/src/main/java/org/springsource/restbucks/payment/OrderPaidEvent.java
@@ -19,19 +19,17 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import org.springframework.context.ApplicationEvent;
-import org.springframework.transaction.event.TransactionBoundApplicationEvent;
 import org.springsource.restbucks.order.Order;
 
 /**
- * {@link ApplicationEvent} to be thrown when an {@link Order} has been payed.
+ * Event to be thrown when an {@link Order} has been payed.
  * 
  * @author Oliver Gierke
  */
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode
 @ToString
-public class OrderPaidEvent extends TransactionBoundApplicationEvent {
+public class OrderPaidEvent  {
 
 	private static final long serialVersionUID = -6150362015056003378L;
 	private final long orderId;
@@ -40,11 +38,8 @@ public class OrderPaidEvent extends TransactionBoundApplicationEvent {
 	 * Creates a new {@link OrderPaidEvent}
 	 * 
 	 * @param orderId the id of the order that just has been payed
-	 * @param source must not be {@literal null}.
 	 */
-	public OrderPaidEvent(long orderId, Object source) {
-
-		super(source);
+	public OrderPaidEvent(long orderId) {
 		this.orderId = orderId;
 	}
 }

--- a/src/main/java/org/springsource/restbucks/payment/PaymentServiceImpl.java
+++ b/src/main/java/org/springsource/restbucks/payment/PaymentServiceImpl.java
@@ -69,7 +69,7 @@ class PaymentServiceImpl implements PaymentService {
 		order.markPaid();
 		CreditCardPayment payment = paymentRepository.save(new CreditCardPayment(creditCard, order));
 
-		publisher.publishEvent(new OrderPaidEvent(order.getId(), this));
+		publisher.publishEvent(new OrderPaidEvent(order.getId()));
 
 		return payment;
 	}


### PR DESCRIPTION
Update restbucks to use the new TransactionalEventListener infrastructure

Note that since the Engine does not implement any application event
related infrastructure, cglib proxies had to be enabled for the event
listener method to be discovered.