### PR TITLE
Fix failing tests because of not cleaning up the database after the integration tests

### DIFF
--- a/src/test/java/org/springsource/restbucks/order/OrderRepositoryIntegrationTest.java
+++ b/src/test/java/org/springsource/restbucks/order/OrderRepositoryIntegrationTest.java
@@ -24,6 +24,7 @@ import org.hamcrest.Matchers;
 import org.javamoney.moneta.Money;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springsource.restbucks.AbstractIntegrationTest;
 
 /**
@@ -31,6 +32,7 @@ import org.springsource.restbucks.AbstractIntegrationTest;
  * 
  * @author Oliver Gierke
  */
+@DirtiesContext
 public class OrderRepositoryIntegrationTest extends AbstractIntegrationTest {
 
 	@Autowired OrderRepository repository;

--- a/src/test/java/org/springsource/restbucks/payment/CreditCardRepositoryIntegrationTest.java
+++ b/src/test/java/org/springsource/restbucks/payment/CreditCardRepositoryIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springsource.restbucks.AbstractIntegrationTest;
 
 /**
@@ -31,6 +32,7 @@ import org.springsource.restbucks.AbstractIntegrationTest;
  * 
  * @author Oliver Gierke
  */
+@DirtiesContext
 public class CreditCardRepositoryIntegrationTest extends AbstractIntegrationTest {
 
 	@Autowired CreditCardRepository repository;

--- a/src/test/java/org/springsource/restbucks/payment/PaymentServiceIntegrationTest.java
+++ b/src/test/java/org/springsource/restbucks/payment/PaymentServiceIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springsource.restbucks.AbstractIntegrationTest;
 import org.springsource.restbucks.order.Order;
 import org.springsource.restbucks.order.Order.Status;
@@ -34,6 +35,7 @@ import org.springsource.restbucks.order.OrderRepository;
  * 
  * @author Oliver Gierke
  */
+@DirtiesContext
 public class PaymentServiceIntegrationTest extends AbstractIntegrationTest {
 
 	@Autowired PaymentService paymentService;


### PR DESCRIPTION
Here is a stacktrace of a downstream test failing:
```
Running org.springsource.restbucks.payment.CreditCardRepositoryIntegrationTest
2016-01-06 12:36:13,668  INFO     o.s.test.context.support.AbstractContextLoader: 242 - Could not detect default resource locations for test class [org.springsource.restbucks.AbstractIntegrationTest]: no resource found for suffixes {-context.xml, Context.groovy}.
2016-01-06 12:36:13,669  INFO     o.s.t.c.support.DefaultTestContextBootstrapper: 259 - Loaded default TestExecutionListener class names from location [META-INF/spring.factories]: [org.springframework.test.context.web.ServletTestExecutionListener, org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener, org.springframework.test.context.support.DependencyInjectionTestExecutionListener, org.springframework.test.context.support.DirtiesContextTestExecutionListener, org.springframework.test.context.transaction.TransactionalTestExecutionListener, org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener]
2016-01-06 12:36:13,670  INFO     o.s.t.c.support.DefaultTestContextBootstrapper: 185 - Using TestExecutionListeners: [org.springframework.test.context.web.ServletTestExecutionListener@27103726, org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener@2df6d461, org.springframework.test.context.support.DependencyInjectionTestExecutionListener@1791670e, org.springframework.test.context.support.DirtiesContextTestExecutionListener@4d5d6297, org.springframework.test.context.transaction.TransactionalTestExecutionListener@6bd2c51d, org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener@709c41da]
2016-01-06 12:36:13,681  INFO    o.s.test.context.transaction.TransactionContext: 101 - Began transaction (1) for test context [DefaultTestContext@2541b4d3 testClass = CreditCardRepositoryIntegrationTest, testInstance = org.springsource.restbucks.payment.CreditCardRepositoryIntegrationTest@6c5e6da, testMethod = createsCreditCard@CreditCardRepositoryIntegrationTest, testException = [null], mergedContextConfiguration = [MergedContextConfiguration@6ca9f1d0 testClass = CreditCardRepositoryIntegrationTest, locations = '{}', classes = '{class org.springsource.restbucks.Restbucks}', contextInitializerClasses = '[]', activeProfiles = '{}', propertySourceLocations = '{}', propertySourceProperties = '{}', contextLoader = 'org.springframework.boot.test.SpringApplicationContextLoader', parent = [null]]]; transaction manager [org.springframework.orm.jpa.JpaTransactionManager@37775bb1]; rollback [true]
2016-01-06 12:36:13,684  WARN   org.hibernate.engine.jdbc.spi.SqlExceptionHelper: 144 - SQL Error: -5501, SQLState: 42501
2016-01-06 12:36:13,685 ERROR   org.hibernate.engine.jdbc.spi.SqlExceptionHelper: 146 - user lacks privilege or object not found: CREDIT_CARD
2016-01-06 12:36:13,686  INFO    o.s.test.context.transaction.TransactionContext: 136 - Rolled back transaction for test context [DefaultTestContext@2541b4d3 testClass = CreditCardRepositoryIntegrationTest, testInstance = org.springsource.restbucks.payment.CreditCardRepositoryIntegrationTest@6c5e6da, testMethod = createsCreditCard@CreditCardRepositoryIntegrationTest, testException = org.springframework.dao.InvalidDataAccessResourceUsageException: could not prepare statement; SQL [insert into credit_card (id, version, card_holder_name, expiry_month, expiry_year, number) values (default, ?, ?, ?, ?, ?)]; nested exception is org.hibernate.exception.SQLGrammarException: could not prepare statement, mergedContextConfiguration = [MergedContextConfiguration@6ca9f1d0 testClass = CreditCardRepositoryIntegrationTest, locations = '{}', classes = '{class org.springsource.restbucks.Restbucks}', contextInitializerClasses = '[]', activeProfiles = '{}', propertySourceLocations = '{}', propertySourceProperties = '{}', contextLoader = 'org.springframework.boot.test.SpringApplicationContextLoader', parent = [null]]].
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.001 sec <<< FAILURE! - in org.springsource.restbucks.payment.CreditCardRepositoryIntegrationTest
createsCreditCard(org.springsource.restbucks.payment.CreditCardRepositoryIntegrationTest)  Time elapsed: 0.001 sec  <<< ERROR!
org.springframework.dao.InvalidDataAccessResourceUsageException: could not prepare statement; SQL [insert into credit_card (id, version, card_holder_name, expiry_month, expiry_year, number) values (default, ?, ?, ?, ?, ?)]; nested exception is org.hibernate.exception.SQLGrammarException: could not prepare statement
	at org.hsqldb.error.Error.error(Unknown Source)
	at org.hsqldb.error.Error.error(Unknown Source)
	at org.hsqldb.ParserDQL.readTableName(Unknown Source)
	at org.hsqldb.ParserDQL.readRangeVariableForDataChange(Unknown Source)
	at org.hsqldb.ParserDML.compileInsertStatement(Unknown Source)
	at org.hsqldb.ParserCommand.compilePart(Unknown Source)
	at org.hsqldb.ParserCommand.compileStatement(Unknown Source)
	at org.hsqldb.Session.compileStatement(Unknown Source)
	at org.hsqldb.StatementManager.compile(Unknown Source)
	at org.hsqldb.Session.execute(Unknown Source)
	at org.hsqldb.jdbc.JDBCPreparedStatement.<init>(Unknown Source)
	at org.hsqldb.jdbc.JDBCConnection.prepareStatement(Unknown Source)
	at sun.reflect.GeneratedMethodAccessor117.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.tomcat.jdbc.pool.ProxyConnection.invoke(ProxyConnection.java:126)
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:108)
	at org.apache.tomcat.jdbc.pool.DisposableConnectionFacade.invoke(DisposableConnectionFacade.java:81)
	at com.sun.proxy.$Proxy70.prepareStatement(Unknown Source)
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl$2.doPrepare(StatementPreparerImpl.java:124)
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl$StatementPreparationTemplate.prepareStatement(StatementPreparerImpl.java:186)
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl.prepareStatement(StatementPreparerImpl.java:122)
	at org.hibernate.id.IdentityGenerator$GetGeneratedKeysDelegate.prepare(IdentityGenerator.java:89)
	at org.hibernate.id.insert.AbstractReturningDelegate.performInsert(AbstractReturningDelegate.java:55)
	at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:3032)
	at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:3558)
	at org.hibernate.action.internal.EntityIdentityInsertAction.execute(EntityIdentityInsertAction.java:98)
	at org.hibernate.engine.spi.ActionQueue.execute(ActionQueue.java:492)
	at org.hibernate.engine.spi.ActionQueue.addResolvedEntityInsertAction(ActionQueue.java:197)
	at org.hibernate.engine.spi.ActionQueue.addInsertAction(ActionQueue.java:181)
	at org.hibernate.engine.spi.ActionQueue.addAction(ActionQueue.java:216)
	at org.hibernate.event.internal.AbstractSaveEventListener.addInsertAction(AbstractSaveEventListener.java:334)
	at org.hibernate.event.internal.AbstractSaveEventListener.performSaveOrReplicate(AbstractSaveEventListener.java:289)
	at org.hibernate.event.internal.AbstractSaveEventListener.performSave(AbstractSaveEventListener.java:195)
	at org.hibernate.event.internal.AbstractSaveEventListener.saveWithGeneratedId(AbstractSaveEventListener.java:126)
	at org.hibernate.jpa.event.internal.core.JpaPersistEventListener.saveWithGeneratedId(JpaPersistEventListener.java:84)
	at org.hibernate.event.internal.DefaultPersistEventListener.entityIsTransient(DefaultPersistEventListener.java:206)
	at org.hibernate.event.internal.DefaultPersistEventListener.onPersist(DefaultPersistEventListener.java:149)
	at org.hibernate.event.internal.DefaultPersistEventListener.onPersist(DefaultPersistEventListener.java:75)
	at org.hibernate.internal.SessionImpl.firePersist(SessionImpl.java:811)
	at org.hibernate.internal.SessionImpl.persist(SessionImpl.java:784)
	at org.hibernate.internal.SessionImpl.persist(SessionImpl.java:789)
	at org.hibernate.jpa.spi.AbstractEntityManagerImpl.persist(AbstractEntityManagerImpl.java:1181)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.springframework.orm.jpa.SharedEntityManagerCreator$SharedEntityManagerInvocationHandler.invoke(SharedEntityManagerCreator.java:293)
	at com.sun.proxy.$Proxy92.persist(Unknown Source)
	at org.springframework.data.jpa.repository.support.SimpleJpaRepository.save(SimpleJpaRepository.java:439)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.executeMethodOn(RepositoryFactorySupport.java:503)
	at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.doInvoke(RepositoryFactorySupport.java:488)
	at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.invoke(RepositoryFactorySupport.java:460)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.invoke(DefaultMethodInvokingMethodInterceptor.java:61)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:281)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:136)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor$CrudMethodMetadataPopulatingMethodInterceptor.invoke(CrudMethodMetadataPostProcessor.java:131)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:92)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:208)
	at org.springsource.restbucks.payment.$Proxy104.save(Unknown Source)
	at org.springsource.restbucks.payment.CreditCardRepositoryIntegrationTest.createsCreditCard(CreditCardRepositoryIntegrationTest.java:41)
```