### PR TITLE
LineItemMixin.amount vs. LineItem.quantity

### DIFF
--- a/src/main/java/org/springsource/restbucks/JacksonCustomizations.java
+++ b/src/main/java/org/springsource/restbucks/JacksonCustomizations.java
@@ -87,7 +87,7 @@ class JacksonCustomizations {
 		static abstract class LineItemMixin {
 
 			@JsonCreator
-			public LineItemMixin(String name, int amount, Milk milk, Size size, Money price) {}
+			public LineItemMixin(String name, int quantity, Milk milk, Size size, Money price) {}
 		}
 
 		@JsonAutoDetect(isGetterVisibility = JsonAutoDetect.Visibility.NONE)


### PR DESCRIPTION
Correct LineItemMixin so that the parameter names in the JsonCreator
match the field names in LineItem. (see
https://github.com/FasterXML/jackson-module-parameter-names ).

I verified that the jackson version currently in use can cope with both cases, so it's only a matter of correctness.