### PR TITLE
Improve serialization of money values

### DIFF
--- a/src/main/java/org/springsource/restbucks/JacksonCustomizations.java
+++ b/src/main/java/org/springsource/restbucks/JacksonCustomizations.java
@@ -103,7 +103,7 @@ class JacksonCustomizations {
 	@SuppressWarnings("serial")
 	static class MoneyModule extends SimpleModule {
 
-		private static final MonetaryAmountFormat FORMAT = MonetaryFormats.getAmountFormat(Locale.US);
+		private static final MonetaryAmountFormat FORMAT = MonetaryFormats.getAmountFormat(Locale.ROOT);
 
 		public MoneyModule() {
 

--- a/src/test/java/org/springsource/restbucks/payment/web/PaymentProcessIntegrationTest.java
+++ b/src/test/java/org/springsource/restbucks/payment/web/PaymentProcessIntegrationTest.java
@@ -126,8 +126,8 @@ public class PaymentProcessIntegrationTest extends AbstractWebIntegrationTest {
 
 	/**
 	 * Creates a new {@link Order} by looking up the orders link from the source and posting the content of
-	 * {@code orders.json} to it. Verifies we get receive a {@code 201 Created} and a {@code Location} header. Follows the
-	 * location header to retrieve the {@link Order} just created.
+	 * {@code orders.json} to it. Verifies we receive a {@code 201 Created} and a {@code Location} header. Follows the
+	 * location header to retrieve and verify the {@link Order} just created.
 	 * 
 	 * @param source
 	 * @return
@@ -148,7 +148,10 @@ public class PaymentProcessIntegrationTest extends AbstractWebIntegrationTest {
 				andExpect(header().string("Location", is(notNullValue()))). //
 				andReturn().getResponse();
 
-		return mvc.perform(get(result.getHeader("Location"))).andReturn().getResponse();
+		return mvc.perform(get(result.getHeader("Location"))).
+				andExpect(jsonPath("$.lineItems[0].quantity", is(1))). //
+				andExpect(jsonPath("$.lineItems[0].price", is("EUR 4.20"))). //
+				andReturn().getResponse();
 	}
 
 	/**


### PR DESCRIPTION
Improves serialization of money values to symmetrically match
deserialization. Serialization used to be without space "EUR1.23" while
deserialization requires money value to be with space.

Added test case.