### PR TITLE
Improve handling of money values (2)

### DIFF
--- a/src/main/java/org/springsource/restbucks/JacksonCustomizations.java
+++ b/src/main/java/org/springsource/restbucks/JacksonCustomizations.java
@@ -87,7 +87,7 @@ class JacksonCustomizations {
 		static abstract class LineItemMixin {
 
 			@JsonCreator
-			public LineItemMixin(String name, int amount, Milk milk, Size size, Money price) {}
+			public LineItemMixin(String name, int quantity, Milk milk, Size size, MonetaryAmount price) {}
 		}
 
 		@JsonAutoDetect(isGetterVisibility = JsonAutoDetect.Visibility.NONE)
@@ -108,7 +108,7 @@ class JacksonCustomizations {
 		public MoneyModule() {
 
 			addSerializer(MonetaryAmount.class, new MonetaryAmountSerializer());
-			addValueInstantiator(Money.class, new MoneyInstantiator());
+			addValueInstantiator(MonetaryAmount.class, new MoneyInstantiator());
 		}
 
 		/**
@@ -141,7 +141,11 @@ class JacksonCustomizations {
 			@Override
 			public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider)
 					throws IOException, JsonGenerationException {
-				jgen.writeString(FORMAT.format((MonetaryAmount) value));
+				if(value != null) {
+					jgen.writeString(String.valueOf(value));
+				} else {
+					jgen.writeNull();
+				}
 			}
 
 			/*
@@ -162,7 +166,7 @@ class JacksonCustomizations {
 			 */
 			@Override
 			public String getValueTypeDesc() {
-				return Money.class.toString();
+				return MonetaryAmount.class.toString();
 			}
 
 			/*

--- a/src/main/java/org/springsource/restbucks/core/MoneyPersistenceConverter.java
+++ b/src/main/java/org/springsource/restbucks/core/MoneyPersistenceConverter.java
@@ -1,0 +1,33 @@
+package org.springsource.restbucks.core;
+
+import java.util.Locale;
+
+import javax.money.MonetaryAmount;
+import javax.money.format.MonetaryAmountFormat;
+import javax.money.format.MonetaryFormats;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import org.javamoney.moneta.Money;
+
+/**
+ * JPA AttributeConverter to serialize MonetaryAmount instances into a String.
+ * autoApplied to all entity properties of type MonetaryAmount.
+ * 
+ * @author Oliver Trosien
+ */
+@Converter(autoApply = true)
+public class MoneyPersistenceConverter implements AttributeConverter<MonetaryAmount, String> {
+
+    private static final MonetaryAmountFormat FORMAT = MonetaryFormats.getAmountFormat(Locale.ROOT);
+
+    @Override
+    public String convertToDatabaseColumn(MonetaryAmount attribute) {
+        return attribute == null ? null : String.valueOf(attribute);
+    }
+
+    @Override
+    public MonetaryAmount convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : Money.parse(dbData, FORMAT);
+    }
+}

--- a/src/main/java/org/springsource/restbucks/order/LineItem.java
+++ b/src/main/java/org/springsource/restbucks/order/LineItem.java
@@ -15,16 +15,14 @@
  */
 package org.springsource.restbucks.order;
 
+import javax.money.MonetaryAmount;
+import javax.persistence.Entity;
+
+import org.springsource.restbucks.core.AbstractEntity;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
-import javax.money.MonetaryAmount;
-import javax.persistence.Entity;
-import javax.persistence.Lob;
-
-import org.javamoney.moneta.Money;
-import org.springsource.restbucks.core.AbstractEntity;
 
 /**
  * A line item.
@@ -41,17 +39,14 @@ public class LineItem extends AbstractEntity {
 	private final int quantity;
 	private final Milk milk;
 	private final Size size;
-	private final @Lob Money price;
+	private final MonetaryAmount price;
 
 	protected LineItem() {
 		this(null, null);
 	}
 
-	public LineItem(String name, Money price) {
+	public LineItem(String name, MonetaryAmount price) {
 		this(name, 1, Milk.SEMI, Size.LARGE, price);
 	}
 
-	public MonetaryAmount getPrice() {
-		return price;
-	}
 }

--- a/src/test/java/org/springsource/restbucks/core/MoneyPersistenceConverterTest.java
+++ b/src/test/java/org/springsource/restbucks/core/MoneyPersistenceConverterTest.java
@@ -1,0 +1,36 @@
+package org.springsource.restbucks.core;
+
+import static org.junit.Assert.*;
+
+import org.javamoney.moneta.Money;
+import org.junit.Test;
+
+public class MoneyPersistenceConverterTest {
+
+	@Test
+	public void testMoneyPersistenceConverter() {
+		MoneyPersistenceConverter converter = new MoneyPersistenceConverter();
+
+		// null-safety
+		assertNull(converter.convertToDatabaseColumn(null));
+		assertNull(converter.convertToEntityAttribute(null));
+
+		// basic conversion
+		assertEquals("EUR 1.23", converter.convertToDatabaseColumn(Money.of(1.23, "EUR")));
+		assertEquals(Money.of(1.23, "EUR"), converter.convertToEntityAttribute("EUR 1.23"));
+
+		// expect no rounding
+		assertEquals("EUR 1.23456", converter.convertToDatabaseColumn(Money.of(1.23456, "EUR")));
+
+		// expect no formatting
+		assertEquals("EUR 123456", converter.convertToDatabaseColumn(Money.of(123456, "EUR")));
+
+		// allow deserialization of formatted values
+		assertEquals(Money.of(123456.78, "EUR"), converter.convertToEntityAttribute("EUR 123,456.78"));
+
+		// support negative values
+		assertEquals("USD -1.2", converter.convertToDatabaseColumn(Money.of(-1.20, "USD")));
+		assertEquals(Money.of(-1.20, "USD"), converter.convertToEntityAttribute("USD -1.2"));
+	}
+
+}


### PR DESCRIPTION
Instead of serializing into a LOB it could be stringified as something
like "EUR 1.23". To do so, you need a JPA AttributeConverter. The serialization logic is intentionally different in the DB than on REST: For serialization no formatting and rounding is applied to keep maximum accuracy. Also, negative values are supported better this way.